### PR TITLE
Sign preferences with id signature, not id value

### DIFF
--- a/mvp-spec/dsp-api.md
+++ b/mvp-spec/dsp-api.md
@@ -719,7 +719,7 @@ The Audit Log contains a list of Preferences with one signature. The UTF-8 strin
 preferences.source.domain + '\u2063' +
 preferences.source.timestamp + '\u2063' +
 
-prebid_id + '\u2063' +
+prebid_id.source.signature + '\u2063' +
 
 preferences.data.key1 + '\u2063' + preferences.data[key1].value + '\u2063' +
 preferences.data.key2 + '\u2063' + preferences.data[key2].value + '\u2063' +


### PR DESCRIPTION
I realized that :
- transmissions are signed with the seed signature (which is obvious, because we don't want to use the whole "seed" data, which is big)
- preferences are signed with the prebid id value

=> For consistency, I think preferences should be signed with id signature, not value.