### PR TITLE
Change last_version_implemented to version in the identity endpoint

### DIFF
--- a/mvp-spec/dsp-implementation.md
+++ b/mvp-spec/dsp-implementation.md
@@ -43,12 +43,16 @@ GET https://<domain>/prebidsso/API/v1/identity
 ## Identity object
 
 It provides the following data as JSON:
+
+<!--partial-begin { "files": [ "identity-table.md" ] } -->
+<!-- ⚠️ GENERATED CONTENT - DO NOT MODIFY DIRECTLY ⚠️ -->
 | Field                    | Type                 | Details                    |
 |--------------------------|----------------------|----------------------------|
 | name                     | String               | The name of the Contracting Party since the domain may not reflect the Company name.<br /> e.g "Criteo"                                                                                                                    |
 | type                     | String               | The type of Contracting Party in the PAF ecosystem. For now, the type for a DSP is "vendor"
-| last_version_implemented | Number               | A two-digit number separated by a point for expressing the last PAF version handled.<br /> For now, the value is "0.1"<br /> Note: a new field may appear with the new versions of the PAF for the last supported version. |
+| version                  | Number               | A two-digit number separated by a point for expressing the last PAF version handled.<br /> For now, the value is "0.1"<br /> Note: a new field may appear with the new versions of the PAF for the last supported version. |
 | keys                     | Array of Key objects | Public keys for verifying the signatures of the DSP. Those public keys are strings associated with a timeframe for handling key rotation.|
+<!--partial-end-->
 
 
 All signatures shared across the network must be verifiable. Therefore, each

--- a/mvp-spec/partials/identity-table.md
+++ b/mvp-spec/partials/identity-table.md
@@ -1,0 +1,6 @@
+| Field                    | Type                 | Details                    |
+|--------------------------|----------------------|----------------------------|
+| name                     | String               | The name of the Contracting Party since the domain may not reflect the Company name.<br /> e.g "Criteo"                                                                                                                    |
+| type                     | String               | The type of Contracting Party in the PAF ecosystem. For now, the type for a DSP is "vendor"
+| version                  | Number               | A two-digit number separated by a point for expressing the last PAF version handled.<br /> For now, the value is "0.1"<br /> Note: a new field may appear with the new versions of the PAF for the last supported version. |
+| keys                     | Array of Key objects | Public keys for verifying the signatures of the DSP. Those public keys are strings associated with a timeframe for handling key rotation.|


### PR DESCRIPTION
Accordingly to a feedback from @kyeliseyev in [this issue](https://github.com/criteo/addressable-network-proposals/issues/59#issuecomment-1025676301).

@OlivierChirouze, I would like also your input regarding this change. I remember that we have had a discussion several month ago on this wording.